### PR TITLE
Add support for new content URLs

### DIFF
--- a/evolvcli/sdk/evolvclient/request.py
+++ b/evolvcli/sdk/evolvclient/request.py
@@ -71,7 +71,9 @@ class EvolvRequest:
             url += '/{}'.format(entity_id)
 
         if content_only:
-            url += '/content'
+            if query is None:
+                query = {}
+            query['content'] = 'true'
 
         if query:
             url += '?{}'.format(parse.urlencode(query))

--- a/evolvcli/sdk/evolvclient/tests/test_evolv_request.py
+++ b/evolvcli/sdk/evolvclient/tests/test_evolv_request.py
@@ -101,10 +101,11 @@ class TestEvolvRequest(unittest.TestCase):
 
         path = requester.request_path(METAMODELS, entity_id=self.METAMODEL_ID, account_id=self.ACCOUNT_ID,
                                       content_only=True)
-        self.assertEqual(path, 'https://{}/{}/accounts/{}/metamodels/{}/content'.format(self.API_DOMAIN,
-                                                                                        self.API_VERSION,
-                                                                                        self.ACCOUNT_ID,
-                                                                                        self.METAMODEL_ID))
+        self.assertEqual(path, 'https://{}/{}/accounts/{}/metamodels/{}{}'.format(self.API_DOMAIN,
+                                                                               self.API_VERSION,
+                                                                               self.ACCOUNT_ID,
+                                                                               self.METAMODEL_ID,
+                                                                               '?content=true'))
 
         query = {'query': 'test'}
         path = requester.request_path(METAMODELS, account_id=self.ACCOUNT_ID, query=query)
@@ -161,7 +162,7 @@ class TestEvolvRequest(unittest.TestCase):
         response = requester.query(METAMODELS)
         self.assertEqual(response, {'test': 1})
 
-        response = requester.query(METAMODELS, 'test')
+        response = requester.query(METAMODELS, {'query': 'test'})
         self.assertEqual(response, {'test': 1})
 
     @patch('evolvclient.request.requests.get', side_effect=mocked_request_bad_response)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
 
 setup(
     name='evolvcli',
-    version='1.0.3',
+    version='1.0.4',
     packages=find_packages(),
     include_package_data=True,
     license='Apache License 2.0',


### PR DESCRIPTION
[RKT-6773]

This PR adds support for new content URLs after the EAPI move to a single lambda
